### PR TITLE
Add regions panel.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2115,8 +2115,7 @@
       "version": "1.7.13",
       "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.13.tgz",
       "integrity": "sha512-obG5TdPdBDfs+jiA1mY29LPFqyJl93Q90EL86ontfRe1B6XvbjPkx+x1aAC5DA18bXbb0Juni1ayDbXo0w1u0A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.3",
@@ -2216,8 +2215,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.6.0.tgz",
       "integrity": "sha512-n3i8htn8pTg9M+kM3cnEfsPZx/6ngInlTroth6fA1LQTJq5aTVQ8ggaE5pPoAy9vCgHPtcaXMzwpldhqRAkebQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vue/compiler-core": {
       "version": "3.2.7",
@@ -2832,8 +2830,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -3157,8 +3154,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "due-console",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "dev": "vite",
     "build": "vite build --emptyOutDir",

--- a/src/App.vue
+++ b/src/App.vue
@@ -84,6 +84,7 @@
             </div>
             <div id="side-bar" class="sm:w-1/2 lg:w-1/3 p-2 space-y-0.5">
                 <LogPanel v-model:log="webSerial.log.value" />
+                <RegionsPanel :regions="webSerial.regions.value" @erase="webSerial.newAll()" @region="webSerial.region($event)" />
                 <HistoryPanel v-model:history="webSerial.history.value" closed />
                 <AboutPanel :available-dfu="availableDfu" :version="webSerial.version.value" />
             </div>
@@ -166,6 +167,7 @@ import Modal from './components/Modal.vue';
 import FirmwareModal from './components/FirmwareModal.vue';
 import DFUModal from './components/DFUModal.vue';
 import LogPanel from './components/LogPanel.vue';
+import RegionsPanel from "./components/RegionsPanel.vue";
 import HistoryPanel from './components/HistoryPanel.vue';
 import AboutPanel from './components/AboutPanel.vue';
 

--- a/src/components/RegionsPanel.vue
+++ b/src/components/RegionsPanel.vue
@@ -1,0 +1,54 @@
+<template>
+    <Panel title="Regions">
+        <template #buttons>
+            <Button :disabled="!regions.length" data-tippy-content="Clear" @click.native.stop="$emit('erase')">
+                <i class="fas fa-fw fa-eraser"></i>
+            </Button>
+        </template>
+        <div v-if="regions.length" class="p-2 whitespace-pre-wrap">
+            <div class="p-2 text-sm divide-y divide-slate-300 dark:divide-zinc-700">
+                <div class="px-2 py-1 grid grid-cols-12 font-medium">
+                    <div class="col-span-1"></div>
+                    <div class="col-span-3">Region</div>
+                    <div class="col-span-5 text-right">Used</div>
+                    <div class="col-span-3 text-right">Total</div>
+                </div>
+                <div
+                    v-for="region in regions"
+                    :class="region?.current ? 'font-medium bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-200' : 'cursor-pointer hover:bg-slate-100 dark:hover:bg-zinc-900'"
+                    class="px-2 py-1 grid grid-cols-12"
+                    @click="region?.current ? undefined : $emit('region', region.index)"
+                >
+                    <div class="col-span-1">
+                        <i v-if="region?.current" class="fas fa-fw fa-angle-right"></i>
+                    </div>
+                    <div class="col-span-3">
+                        {{ region?.index || 0 }}
+                    </div>
+                    <div class="col-span-5 text-right">
+                        {{ region?.used || 0 }}
+                    </div>
+                    <div class="col-span-3 text-right">
+                        {{ region?.total || 0 }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </Panel>
+</template>
+
+<script setup>
+// Components
+
+import Panel from './Panel.vue';
+import Button from './Button.vue';
+
+// Props
+
+const props = defineProps({
+    regions: {
+        type: Array,
+        default: () => [],
+    },
+});
+</script>

--- a/src/js/useWebSerial.js
+++ b/src/js/useWebSerial.js
@@ -133,7 +133,6 @@ export default function useWebSerial($refs) {
                 logEvent(data.message);
                 break;
             case 'memoryRegionsResult':
-                console.log('memoryRegionsResult');
                 regions.value = [];
                 // Ignore the headings.
                 data.result.shift();
@@ -151,7 +150,6 @@ export default function useWebSerial($refs) {
                         total: info[2],
                     });
                 });
-                console.log(regions.value);
                 break;
             case 'output':
                 log.value = data.value;

--- a/src/js/useWebSerial.js
+++ b/src/js/useWebSerial.js
@@ -12,6 +12,7 @@ export default function useWebSerial($refs) {
     const isStopped = ref(true);
     const isTalking = ref(false);
     const log = ref('');
+    const regions = ref([]);
     const version = ref(null);
 
     // Setup
@@ -55,24 +56,43 @@ export default function useWebSerial($refs) {
         worker.postMessage({ task: 'disconnect' });
     }
 
-    function record(lines) {
-        worker.postMessage({ task: 'record', lines });
-    }
-
-    function play() {
-        worker.postMessage({ task: 'play' });
-    }
-
-    function stop() {
-        worker.postMessage({ task: 'stop' });
+    function execute(line) {
+        worker.postMessage({ task: 'execute', line });
     }
 
     function list(callback = null) {
         worker.postMessage({ task: 'list', callbackId: storeCallback(callback) });
     }
 
-    function execute(line) {
-        worker.postMessage({ task: 'execute', line });
+    function memoryRegions() {
+        worker.postMessage({ task: 'memoryRegions' });
+    }
+
+    /**
+     * Request the worker to erase all regions.
+     */
+    function newAll() {
+        worker.postMessage({ task: 'newAll' });
+    }
+
+    function play() {
+        worker.postMessage({ task: 'play' });
+    }
+
+    function record(lines) {
+        worker.postMessage({ task: 'record', lines });
+    }
+
+    /**
+     * Request the worker to select a region.
+     * @param {Number} index
+     */
+    function region(index) {
+        worker.postMessage({ task: 'region', index });
+    }
+
+    function stop() {
+        worker.postMessage({ task: 'stop' });
     }
 
     // Methods - Utilities
@@ -91,6 +111,7 @@ export default function useWebSerial($refs) {
                 isBusy.value = false;
                 isConnected.value = true;
                 logEvent('Port connected.');
+                memoryRegions();
                 break;
             case 'disconnected':
                 isConnected.value = false;
@@ -98,6 +119,9 @@ export default function useWebSerial($refs) {
                 break;
             case 'isTalking':
                 isTalking.value = data.value;
+                if (data.lastCommand.startsWith('region')) {
+                    memoryRegions();
+                }
                 break;
             case 'logError':
                 logError(data.message);
@@ -107,6 +131,27 @@ export default function useWebSerial($refs) {
                 break;
             case 'logEvent':
                 logEvent(data.message);
+                break;
+            case 'memoryRegionsResult':
+                console.log('memoryRegionsResult');
+                regions.value = [];
+                // Ignore the headings.
+                data.result.shift();
+                // Make more usable.
+                data.result.forEach((info) => {
+                    info = info.match(/(\*?\d+)/gm);
+                    const current = info[0].startsWith('*');
+                    if (current) {
+                        info[0] = info[0].substring(1, info[0].length);
+                    }
+                    regions.value.push({
+                        current,
+                        index: info[0],
+                        used: info[1],
+                        total: info[2],
+                    });
+                });
+                console.log(regions.value);
                 break;
             case 'output':
                 log.value = data.value;
@@ -130,6 +175,9 @@ export default function useWebSerial($refs) {
                 $refs.progress.style.width = '100%';
                 $refs.progress.classList.add('opacity-0');
                 break;
+            case 'regionSelected':
+                regions.value.forEach((region) => region.current = region.index === data.index);
+                break;
             case 'stopped':
                 isPlaying.value = false;
                 isStopped.value = true;
@@ -148,7 +196,7 @@ export default function useWebSerial($refs) {
                 const index = data.message.indexOf(':');
                 let msg = data.message               
                 
-                if (index != -1)
+                if (index !== -1)
                     msg = data.message.substring(0, index)
 
                 alert(msg)
@@ -176,14 +224,17 @@ export default function useWebSerial($refs) {
         isStopped,
         isTalking,
         log,
+        regions,
         version,
         // Methods
         connect,
         disconnect,
         execute,
         list,
+        newAll,
         play,
         record,
+        region,
         stop,
     };
 }

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -177,7 +177,7 @@ async function record(lines) {
         if (line.trim().length === 0) {
             line = ' ';
         }
-        console.log('line', `"${line}"`);
+        log('line', `"${line}"`);
         await stream(line + '\n');
         postMessage({ event: 'recording', percent: (++lineNumber/lines.length) * 100 });
     }

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -2,6 +2,7 @@ importScripts('../consumer-queue.min.js');
 
 const decoder = new TextDecoder();
 const encoder = new TextEncoder();
+let ignoreOutput = false;
 let isConnected = false;
 let isEchoing = true;
 let isLogging = true;
@@ -35,11 +36,20 @@ addEventListener('message', (e) => {
         case 'list':
             list(e.data.callbackId);
             break;
+        case 'memoryRegions':
+            memoryRegions();
+            break;
+        case 'newAll':
+            newAll();
+            break;
         case 'play':
             play();
             break;
         case 'record':
             record(e.data.lines);
+            break;
+        case 'region':
+            region(e.data.index);
             break;
         case 'stop':
             stop();
@@ -113,7 +123,13 @@ async function disconnect() {
 
 async function execute(line) {
     await write('>');
-    await write(line);
+    line = line.toLowerCase();
+    if (line.startsWith('mem')) {
+        const result = await write(line);
+        postMessage({ event: 'memoryRegionsResult', result });
+    } else {
+        await write(line);
+    }
     logEvent(`Executed: &nbsp;<code>${line}</code>`);
 }
 
@@ -121,6 +137,23 @@ async function list(callbackId) {
     const result = await write('list');
     postMessage({ event: 'writeResult', callbackId, result });
     logEvent('Listed program code.');
+}
+
+async function memoryRegions() {
+    ignoreOutput = true;
+    await write('>');
+    const result = await write('mem()');
+    postMessage({ event: 'memoryRegionsResult', result });
+    ignoreOutput = false;
+}
+
+/**
+ * Erase all regions.
+ */
+async function newAll() {
+    await write('>');
+    await write('new all');
+    await memoryRegions();
 }
 
 async function play() {
@@ -156,6 +189,16 @@ async function record(lines) {
 
     postMessage({ event: 'recorded' });
     logEvent('Recorded ' + lines.length + ' line(s) of code.');
+}
+
+/**
+ * Select a region.
+ * @param {Number} index
+ */
+async function region(index) {
+    await write('>');
+    await write(`region(${index})`);
+    postMessage({ event: 'regionSelected', index });
 }
 
 async function stop() {
@@ -248,8 +291,10 @@ async function readLoop() {
                         postOutput = false;
                     }
                 }
-                if (postOutput) {
+                if (postOutput && !ignoreOutput) {
                     postMessage({ event: 'output', value: output });
+                } else if (ignoreOutput) {
+                    output = '';
                 }
             }
 
@@ -402,6 +447,8 @@ async function synchronize() {
         }
         tryCount--;
     }
+
+
 }
 
 async function turnOffEcho() {
@@ -433,6 +480,6 @@ async function write(command, terminator = null, lineEnd = '\n') {
         log('write result', result);
         return result;
     } finally {
-        postMessage({ event: 'isTalking', value: false });
+        postMessage({ event: 'isTalking', value: false, lastCommand: command });
     }
 }


### PR DESCRIPTION
- Added regions panel that shows region information. Updates on:
    - If first connect.
    - If `mem` or `region` are executed
    - If erase button is pressed
- Erase button erases all regions e.g. `new all`
- Clicking a row selects that region e.g. `region(x)`
- There could be a button to add regions too, but when I test on my board I can only do `region(1)` to create a second region. I cannot do `region(2)`, etc..

<img width="869" height="392" alt="image" src="https://github.com/user-attachments/assets/b4d2a139-8b41-49da-abb1-68c3969c9815" />

---

I also cannot update the firmware on my board. I am one version behind. Holding LDR while resetting doesn't bring up DFU in FS mode in the browser window.

<img width="856" height="283" alt="image" src="https://github.com/user-attachments/assets/bcd1a4f9-39f5-4fbc-8325-d6f8b344691e" />

